### PR TITLE
renamed `@typescript-eslint/no-unused-vars`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtvmbh/eslint-config",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "ESLint configurations for various project types developed by Gesellschaft für Technische Visualistik",
   "main": "index.js",
   "scripts": {

--- a/src/jsdoc.js
+++ b/src/jsdoc.js
@@ -3,6 +3,5 @@ module.exports = {
     'jsdoc'
   ],
   rules: {
-    'jsdoc/newline-after-description': 'warn'
   }
 };

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -156,7 +156,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-return': 'warn',
     
     // Disallow unused variables and arguments
-    '@typescript-eslint/no-unused-vars-experimental': 'warn', // aber lieber über compiler (siehe beschreibung)?,
+    '@typescript-eslint/no-unused-vars': 'warn', // aber lieber über compiler (siehe beschreibung)?,
     
     // Disallows the use of require statements except in import statements
     '@typescript-eslint/no-var-requires': 'error',


### PR DESCRIPTION
removed `jsdoc/newline-after-description`
incremented version to 1.0.9

close #6 